### PR TITLE
fix: add missing PPC arch enum value

### DIFF
--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -29,6 +29,7 @@ class DebianArchitecture(str, enum.Enum):
     ARM64 = "arm64"
     ARMHF = "armhf"
     I386 = "i386"
+    PPC = "powerpc"
     PPC64EL = "ppc64el"
     RISCV64 = "riscv64"
     S390X = "s390x"


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
"powerpc" is missing from the valid enum values.

(CRAFT-3078)