### PR TITLE
style(lint): fix ruff 0.6.0 linting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,9 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.15"
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [check, --fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
     rev: "24.1.1"
     hooks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import types
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def project_main_module() -> types.ModuleType:
     """Fixture that returns the project's principal package (imported).
 


### PR DESCRIPTION
Also bumps the pre-commit config to use rolling ruff versions

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
