### PR TITLE
fix: better compatibility for craft-providers

### DIFF
--- a/craft_platforms/__init__.py
+++ b/craft_platforms/__init__.py
@@ -31,7 +31,7 @@ from ._errors import (
     NeedBuildBaseError,
     RequiresBaseError,
 )
-from ._platforms import Platforms, get_platforms_build_plan
+from ._platforms import PlatformDict, Platforms, get_platforms_build_plan
 
 try:
     from ._version import (
@@ -53,6 +53,8 @@ __all__ = [
     "rock",
     "snap",
     "get_platforms_build_plan",
+    "PlatformDict",
+    "Platforms",
     "BaseName",
     "DistroBase",
     "is_ubuntu_like",

--- a/craft_platforms/_distro.py
+++ b/craft_platforms/_distro.py
@@ -34,8 +34,11 @@ class BaseName(typing.Protocol):
     language used in craft-providers.
     """
 
-    name: str
-    version: str
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
 
 
 def _get_version_tuple(version_str: str) -> tuple[int | str, ...]:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Fixes https://github.com/canonical/craft-platforms/issues/43 and ensures that `BaseName` properties are read-only as is the case for NamedTuples