### PR TITLE
ci: match jira label with charm-engineering label

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -2,7 +2,7 @@ settings:
   components:
     - Craft Platforms
   labels:
-    - Triaged
+    - "Status: Triaged"
   # Adds a comment with the JIRA ID
   add_gh_comment: true
   # Reflect changes on JIRA


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

-----

Match the jira bot's label with the label defined in https://github.com/canonical/charm-engineering-repos/blob/7b499bfb0642ef7a2c43d5b00d51ff80aa533f4e/charm-engineering-teams/starcraft/repos/common.hcl#L28