### PR TITLE
feat: multi-base support for charm build plans

### DIFF
--- a/craft_platforms/__init__.py
+++ b/craft_platforms/__init__.py
@@ -15,7 +15,7 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Package base for craft_platforms."""
 
-from ._architectures import DebianArchitecture, get_base_and_architecture
+from ._architectures import DebianArchitecture, parse_base_and_architecture
 from ._buildinfo import BuildInfo
 from . import charm, rock, snap
 from ._distro import BaseName, DistroBase, is_ubuntu_like
@@ -34,7 +34,7 @@ from ._platforms import (
     PlatformDict,
     Platforms,
     get_platforms_build_plan,
-    get_base_and_name,
+    parse_base_and_name,
 )
 
 try:
@@ -53,11 +53,12 @@ __all__ = [
     "__version__",
     "DebianArchitecture",
     "BuildInfo",
+    "parse_base_and_architecture",
     "charm",
     "rock",
     "snap",
     "get_platforms_build_plan",
-    "get_base_and_name",
+    "parse_base_and_name",
     "PlatformDict",
     "Platforms",
     "BaseName",

--- a/craft_platforms/__init__.py
+++ b/craft_platforms/__init__.py
@@ -15,7 +15,7 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Package base for craft_platforms."""
 
-from ._architectures import DebianArchitecture
+from ._architectures import DebianArchitecture, get_base_and_architecture
 from ._buildinfo import BuildInfo
 from . import charm, rock, snap
 from ._distro import BaseName, DistroBase, is_ubuntu_like
@@ -30,7 +30,12 @@ from ._errors import (
     NeedBuildBaseError,
     RequiresBaseError,
 )
-from ._platforms import PlatformDict, Platforms, get_platforms_build_plan
+from ._platforms import (
+    PlatformDict,
+    Platforms,
+    get_platforms_build_plan,
+    get_base_and_name,
+)
 
 try:
     from ._version import (
@@ -52,6 +57,7 @@ __all__ = [
     "rock",
     "snap",
     "get_platforms_build_plan",
+    "get_base_and_name",
     "PlatformDict",
     "Platforms",
     "BaseName",

--- a/craft_platforms/__init__.py
+++ b/craft_platforms/__init__.py
@@ -29,6 +29,7 @@ from ._errors import (
     InvalidPlatformError,
     NeedBuildBaseError,
     RequiresBaseError,
+    InvalidMultiBaseError,
 )
 from ._platforms import (
     PlatformDict,
@@ -73,4 +74,5 @@ __all__ = [
     "InvalidPlatformError",
     "RequiresBaseError",
     "NeedBuildBaseError",
+    "InvalidMultiBaseError",
 ]

--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -79,22 +79,23 @@ _ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
 }
 
 
-def get_base_and_architecture(
-    *, architecture: str
+def parse_base_and_architecture(
+    *, arch: str
 ) -> Tuple[Optional[_distro.DistroBase], Union[DebianArchitecture, Literal["all"]]]:
     """Get the debian arch and optional base from an architecture entry.
 
     The architecture may have an optional base prefixed as '[<base>:]<arch>'.
 
-    :param architecture: The architecture entry.
+    :param arch: The architecture entry.
 
-    :returns: A tuple of the DistroBase and the DebianArchitecture or 'all'.
+    :returns: A tuple of the DistroBase and the architecture. The architecture is either
+     a DebianArchitecture or 'all'.
     """
-    if ":" in architecture:
-        base_str, _, arch_str = architecture.partition(":")
+    if ":" in arch:
+        base_str, _, arch_str = arch.partition(":")
         base = _distro.DistroBase.from_str(base_str)
     else:
         base = None
-        arch_str = architecture
+        arch_str = arch
 
     return base, DebianArchitecture(arch_str) if arch_str != "all" else "all"

--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -80,7 +80,7 @@ _ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
 
 
 def parse_base_and_architecture(
-    *, arch: str
+    arch: str,
 ) -> Tuple[Optional[_distro.DistroBase], Union[DebianArchitecture, Literal["all"]]]:
     """Get the debian arch and optional base from an architecture entry.
 

--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -19,8 +19,11 @@ from __future__ import annotations
 
 import enum
 import platform
+from typing import Literal, Optional, Tuple, Union
 
 from typing_extensions import Self
+
+from craft_platforms import _distro
 
 
 class DebianArchitecture(str, enum.Enum):
@@ -74,3 +77,24 @@ _ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
 _ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
     deb: platform for platform, deb in _ARCH_TRANSLATIONS_PLATFORM_TO_DEB.items()
 }
+
+
+def get_base_and_architecture(
+    *, architecture: str
+) -> Tuple[Optional[_distro.DistroBase], Union[DebianArchitecture, Literal["all"]]]:
+    """Get the debian arch and optional base from an architecture entry.
+
+    The architecture may have an optional base prefixed as '[<base>:]<arch>'.
+
+    :param architecture: The architecture entry.
+
+    :returns: A tuple of the DistroBase and the DebianArchitecture or 'all'.
+    """
+    if ":" in architecture:
+        base_str, _, arch_str = architecture.partition(":")
+        base = _distro.DistroBase.from_str(base_str)
+    else:
+        base = None
+        arch_str = architecture
+
+    return base, DebianArchitecture(arch_str) if arch_str != "all" else "all"

--- a/craft_platforms/_errors.py
+++ b/craft_platforms/_errors.py
@@ -207,3 +207,7 @@ class InvalidBaseError(CraftPlatformsError, ValueError):
 
 class RequiresBaseError(CraftPlatformsError, ValueError):
     """Error when a base is required in this configuration."""
+
+
+class InvalidMultiBaseError(CraftPlatformsError, ValueError):
+    """Error when a multi-base configuration is invalid."""

--- a/craft_platforms/_platforms.py
+++ b/craft_platforms/_platforms.py
@@ -99,9 +99,7 @@ def get_platforms_build_plan(
     return build_plan
 
 
-def parse_base_and_name(
-    *, platform_name: str
-) -> Tuple[Optional[_distro.DistroBase], str]:
+def parse_base_and_name(platform_name: str) -> Tuple[Optional[_distro.DistroBase], str]:
     """Get the platform name and optional base from a platform name.
 
     The platform name may have an optional base prefix as '[<base>:]<platform>'.

--- a/craft_platforms/_platforms.py
+++ b/craft_platforms/_platforms.py
@@ -99,7 +99,7 @@ def get_platforms_build_plan(
     return build_plan
 
 
-def get_base_and_name(
+def parse_base_and_name(
     *, platform_name: str
 ) -> Tuple[Optional[_distro.DistroBase], str]:
     """Get the platform name and optional base from a platform name.

--- a/craft_platforms/_platforms.py
+++ b/craft_platforms/_platforms.py
@@ -17,7 +17,7 @@
 
 import itertools
 import typing
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import annotated_types
 from typing_extensions import Annotated
@@ -97,3 +97,24 @@ def get_platforms_build_plan(
             raise _errors.AllOnlyBuildError(platforms_with_all)
 
     return build_plan
+
+
+def get_base_and_name(
+    *, platform_name: str
+) -> Tuple[Optional[_distro.DistroBase], str]:
+    """Get the platform name and optional base from a platform name.
+
+    The platform name may have an optional base prefix as '[<base>:]<platform>'.
+
+    :param platform_name: The name of the platform.
+
+    :returns: A tuple of the DistroBase and the platform name.
+    """
+    if ":" in platform_name:
+        base_str, _, name = platform_name.partition(":")
+        base = _distro.DistroBase.from_str(base_str)
+    else:
+        base = None
+        name = platform_name
+
+    return base, name

--- a/craft_platforms/charm/_build.py
+++ b/craft_platforms/charm/_build.py
@@ -33,14 +33,134 @@ If no platforms are defined, the charm will be built on and for these architectu
 """
 
 
+def _validate_base_definition(
+    base: Optional[str],
+    build_base: Optional[str],
+    platform_name: Optional[str],
+    platform: Optional[_platforms.PlatformDict],
+) -> None:
+    """Validate that a base is defined correctly in the data used to create a build.
+
+    The rules are:
+     - a base must be defined in only one place
+     - each platform must build on and build for the same base
+
+    :raises ValueError: If the base is not defined correctly in the build data.
+    """
+    if not (platform_name or base or build_base):
+        raise ValueError("No base, build-base, or platforms are specified.")
+
+    if platform_name:
+        # validate base defined in the platform name
+        platform_base, _ = _platforms.get_base_and_name(platform_name=platform_name)
+
+        if platform_base and (base or build_base):
+            raise ValueError(
+                f"Platform {platform_name!r} specifies a base and a top-level base "
+                "or build-base is specified."
+            )
+
+        # validate bases defined in build-on and build-for entries
+        if platform:
+            # create a set of all bases defined in the build-on and build-for entries
+            build_on_for_bases = set()
+            for entry in [*platform["build-on"], *platform["build-for"]]:
+                build_on_for_distro_base = _architectures.get_base_and_architecture(
+                    architecture=entry
+                )[0]
+                build_on_for_bases.add(
+                    str(build_on_for_distro_base) if build_on_for_distro_base else None
+                )
+
+            if len(build_on_for_bases) == 0:
+                build_on_for_base = None
+            elif len(build_on_for_bases) == 1:
+                # grab the first element
+                build_on_for_base = next(iter(build_on_for_bases))
+            else:
+                raise ValueError(
+                    f"Platform {platform_name!r} has mismatched bases in the 'build-on' "
+                    "and 'build-for' entries."
+                )
+
+            if platform_base and build_on_for_base:
+                raise ValueError(
+                    f"Platform {platform_name!r} declares a base in the platform name "
+                    "and in 'build-on' and 'build-for' entries. "
+                )
+        else:
+            build_on_for_base = None
+
+        if (platform_base or build_on_for_base) and (base or build_base):
+            raise ValueError(
+                f"Platform {platform_name!r} specifies a base and a top-level base "
+                "or build-base is specified."
+            )
+
+        if not (platform_base or build_on_for_base) and not (base or build_base):
+            raise ValueError(
+                "No base or build-base is specified and no base is specified "
+                "in the platforms section."
+            )
+
+
+def _get_base_from_build_data(
+    base: Optional[str],
+    build_base: Optional[str],
+    platform_name: Optional[str],
+    platform: Optional[_platforms.PlatformDict],
+) -> _distro.DistroBase:
+    """Get the base from a data used to create a build.
+
+    :returns: The base to use for a build.
+
+    :raises ValueError: If the base is not defined correctly in the build data.
+    """
+    _validate_base_definition(
+        base=base,
+        build_base=build_base,
+        platform_name=platform_name,
+        platform=platform,
+    )
+
+    if build_base:
+        return _distro.DistroBase.from_str(build_base)
+
+    if base:
+        return _distro.DistroBase.from_str(base)
+
+    if platform_name:
+        platform_base, _ = _platforms.get_base_and_name(platform_name=platform_name)
+        if platform_base:
+            return platform_base
+
+        # build-on and build-for entries all have the same base, so we only
+        # need to check one of them
+        if platform:
+            build_for_base, _ = _architectures.get_base_and_architecture(
+                architecture=platform["build-for"][0]
+            )
+            if build_for_base:
+                return build_for_base
+
+    # if this is raised, then the validator is not working correctly
+    raise ValueError("Could not determine the base for the build.")
+
+
 def get_platforms_charm_build_plan(
-    base: str,
+    base: Optional[str],
     platforms: Optional[_platforms.Platforms],
     build_base: Optional[str] = None,
 ) -> Sequence[_buildinfo.BuildInfo]:
     """Generate the build plan for a platforms-based charm."""
-    distro_base = _distro.DistroBase.from_str(build_base or base)
     if platforms is None:
+        distro_base = _get_base_from_build_data(
+            base=base,
+            build_base=build_base,
+            platform_name=None,
+            platform=None,
+        )
+
         # If no platforms are specified, build for all default architectures without
         # an option of cross-compiling.
         return [
@@ -54,20 +174,34 @@ def get_platforms_charm_build_plan(
         ]
     build_plan: List[_buildinfo.BuildInfo] = []
     for platform_name, platform in platforms.items():
+        distro_base = _get_base_from_build_data(
+            base=base,
+            build_base=build_base,
+            platform_name=platform_name,
+            platform=platform,
+        )
+
+        _, platform_name_without_base = _platforms.get_base_and_name(
+            platform_name=platform_name
+        )
+
         if platform is None:
             # This is a workaround for Python 3.10.
             # In python 3.12+ we can just check:
             # `if platform_name not in _architectures.DebianArchitecture`
             try:
-                architecture = _architectures.DebianArchitecture(platform_name)
+                architecture = _architectures.DebianArchitecture(
+                    platform_name_without_base
+                )
             except ValueError:
                 raise ValueError(
                     f"Platform name {platform_name!r} is not a valid Debian architecture. "
                     "Specify a build-on and build-for.",
                 ) from None
+
             build_plan.append(
                 _buildinfo.BuildInfo(
-                    platform=platform_name,
+                    platform=platform_name_without_base,
                     build_on=architecture,
                     build_for=architecture,
                     build_base=distro_base,
@@ -78,12 +212,25 @@ def get_platforms_charm_build_plan(
                 platform["build-on"],
                 platform["build-for"],
             ):
+                build_on_base, build_on_arch = _architectures.get_base_and_architecture(
+                    architecture=build_on
+                )
+                if build_on_arch == "all":
+                    raise ValueError(
+                        f"Platform {platform_name!r} has an invalid 'build-on' entry of 'all'."
+                    )
+
+                build_for_base, build_for_arch = (
+                    _architectures.get_base_and_architecture(architecture=build_for)
+                )
+
                 build_plan.append(
                     _buildinfo.BuildInfo(
-                        platform=platform_name,
-                        build_on=_architectures.DebianArchitecture(build_on),
-                        build_for=_architectures.DebianArchitecture(build_for),
+                        platform=platform_name_without_base,
+                        build_on=build_on_arch,
+                        build_for=build_for_arch,
                         build_base=distro_base,
                     ),
                 )
+
     return build_plan

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+0.5.0 (2024-12-XX)
+------------------
+
+Features
+========
+
+- Add multi-base support for charm build plans
+
 0.4.0 (2024-10-17)
 ------------------
 

--- a/tests/unit/charm/test_build.py
+++ b/tests/unit/charm/test_build.py
@@ -284,6 +284,10 @@ def test_build_plans_success(
             None,
             None,
             {
+                "jammy": {
+                    "build-on": ["ubuntu@22.04:amd64"],
+                    "build-for": ["ubuntu@22.04:all"],
+                },
                 "noble": {
                     "build-on": ["ubuntu@24.04:amd64"],
                     "build-for": ["ubuntu@24.04:all"],
@@ -291,11 +295,17 @@ def test_build_plans_success(
             },
             [
                 craft_platforms.BuildInfo(
+                    "jammy",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    "all",
+                    craft_platforms.DistroBase("ubuntu", "22.04"),
+                ),
+                craft_platforms.BuildInfo(
                     "noble",
                     craft_platforms.DebianArchitecture("amd64"),
                     "all",
                     craft_platforms.DistroBase("ubuntu", "24.04"),
-                )
+                ),
             ],
             id="multi-base-all",
         ),

--- a/tests/unit/charm/test_build.py
+++ b/tests/unit/charm/test_build.py
@@ -208,6 +208,149 @@ def test_build_plans_success(
             ],
             id="multiple-builds",
         ),
+        pytest.param(
+            None,
+            None,
+            {
+                "noble": {
+                    "build-on": ["ubuntu@24.04:amd64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            [
+                craft_platforms.BuildInfo(
+                    "noble",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                )
+            ],
+            id="multi-base-simple",
+        ),
+        pytest.param(
+            None,
+            None,
+            {"ubuntu@24.04:amd64": None},
+            [
+                craft_platforms.BuildInfo(
+                    "amd64",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                )
+            ],
+            id="multi-base-shorthand",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                # base and arch in platform name
+                "ubuntu@20.04:amd64": None,
+                # base in platform name
+                "ubuntu@22.04:jammy": {
+                    "build-on": ["amd64"],
+                    "build-for": ["amd64"],
+                },
+                # nothing in platform name
+                "noble": {
+                    "build-on": ["ubuntu@24.04:amd64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            [
+                craft_platforms.BuildInfo(
+                    "amd64",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "20.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "jammy",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "22.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "noble",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                ),
+            ],
+            id="multi-base-mixed-notation",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "noble": {
+                    "build-on": ["ubuntu@24.04:amd64"],
+                    "build-for": ["ubuntu@24.04:all"],
+                },
+            },
+            [
+                craft_platforms.BuildInfo(
+                    "noble",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    "all",
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                )
+            ],
+            id="multi-base-all",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "ubuntu@20.04:amd64": None,
+                "jammy": {
+                    "build-on": ["ubuntu@22.04:amd64"],
+                    "build-for": ["ubuntu@22.04:amd64"],
+                },
+                "noble": {
+                    "build-on": ["ubuntu@22.04:amd64"],
+                    "build-for": ["ubuntu@22.04:amd64"],
+                },
+                "noble-cross": {
+                    "build-on": ["ubuntu@24.04:amd64", "ubuntu@24.04:riscv64"],
+                    "build-for": ["ubuntu@24.04:riscv64"],
+                },
+            },
+            [
+                craft_platforms.BuildInfo(
+                    "amd64",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "20.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "jammy",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "22.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "noble",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "22.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "noble-cross",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("riscv64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "noble-cross",
+                    craft_platforms.DebianArchitecture("riscv64"),
+                    craft_platforms.DebianArchitecture("riscv64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                ),
+            ],
+            id="multi-base-complex",
+        ),
     ],
 )
 def test_build_plans_in_depth(base, build_base, platforms, expected):
@@ -222,17 +365,124 @@ def test_build_plans_in_depth(base, build_base, platforms, expected):
 
 
 @pytest.mark.parametrize(
-    ("base", "error_msg"),
+    ("base", "build_base", "platforms", "error_msg"),
     [
-        (
+        pytest.param(
             "invalid-base",
+            None,
+            None,
             "Invalid base string 'invalid-base'. Format should be '<distribution>@<series>'",
+            id="invalid-base",
+        ),
+        pytest.param(
+            None,
+            None,
+            None,
+            "No base, build-base, or platforms are specified.",
+            id="no-base-no-platform",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "my-platform": {
+                    "build-on": ["amd64"],
+                    "build-for": ["amd64"],
+                },
+            },
+            "No base or build-base is specified and no base is specified in the platforms section.",
+            id="no-base-with-platform",
+        ),
+        pytest.param(
+            None,
+            None,
+            {"amd64": None},
+            "No base or build-base is specified and no base is specified in the platforms section.",
+            id="no-base-with-shorthand-platform",
+        ),
+        pytest.param(
+            "ubuntu@24.04",
+            None,
+            {"ubuntu@24.04:amd64": None},
+            "Platform 'ubuntu@24.04:amd64' specifies a base and a top-level base or build-base is specified.",
+            id="base-and-platform-base",
+        ),
+        pytest.param(
+            None,
+            "ubuntu@24.04",
+            {"ubuntu@24.04:amd64": None},
+            "Platform 'ubuntu@24.04:amd64' specifies a base and a top-level base or build-base is specified.",
+            id="build-base-and-platform-base",
+        ),
+        pytest.param(
+            "ubuntu@24.04",
+            None,
+            {
+                "my-platform": {
+                    "build-on": ["ubuntu@24.04:amd64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            "Platform 'my-platform' specifies a base and a top-level base or build-base is specified.",
+            id="base-and-build-on-for-base",
+        ),
+        pytest.param(
+            None,
+            "ubuntu@24.04",
+            {
+                "my-platform": {
+                    "build-on": ["ubuntu@24.04:amd64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            "Platform 'my-platform' specifies a base and a top-level base or build-base is specified.",
+            id="build-base-and-build-on-for-base",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "my-platform": {
+                    "build-on": ["ubuntu@22.04:amd64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            "Platform 'my-platform' has mismatched bases in the 'build-on' and 'build-for' entries.",
+            id="build-on-for-base-mismatch",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "my-platform": {
+                    "build-on": ["ubuntu@22.04:amd64"],
+                    "build-for": ["amd64"],
+                },
+            },
+            "Platform 'my-platform' has mismatched bases in the 'build-on' and 'build-for' entries.",
+            id="build-on-for-base-missing",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "ubuntu@24.04:amd64": {
+                    "build-on": ["ubuntu@24.04:amd64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            "Platform 'ubuntu@24.04:amd64' declares a base in the platform name and in 'build-on' and 'build-for' entries. ",
+            id="platform-base-and-build-on-for-base",
         ),
     ],
 )
-def test_build_plans_bad_base(base, error_msg):
+def test_build_plans_bad_base(base, build_base, platforms, error_msg):
     with pytest.raises(ValueError, match=error_msg):
-        charm.get_platforms_charm_build_plan(base, None)
+        charm.get_platforms_charm_build_plan(
+            base=base,
+            build_base=build_base,
+            platforms=platforms,
+        )
 
 
 @pytest.mark.parametrize(
@@ -247,6 +497,11 @@ def test_build_plans_bad_base(base, error_msg):
             {"my machine": {"build-on": ["my machine"], "build-for": ["amd64"]}},
             "'my machine' is not a valid DebianArchitecture",
             id="invalid-architecture-name",
+        ),
+        pytest.param(
+            {"my machine": {"build-on": ["all"], "build-for": ["amd64"]}},
+            "Platform 'my machine' has an invalid 'build-on' entry of 'all'.",
+            id="build-on-all",
         ),
     ],
 )

--- a/tests/unit/test_architectures.py
+++ b/tests/unit/test_architectures.py
@@ -62,4 +62,4 @@ def test_debian_architecture_from_host(monkeypatch, machine):
     ],
 )
 def test_get_base_and_architecture(given, expected):
-    assert parse_base_and_architecture(arch=given) == expected
+    assert parse_base_and_architecture(given) == expected

--- a/tests/unit/test_architectures.py
+++ b/tests/unit/test_architectures.py
@@ -18,7 +18,7 @@
 import platform
 
 import pytest
-from craft_platforms import DebianArchitecture
+from craft_platforms import DebianArchitecture, DistroBase, get_base_and_architecture
 
 
 @pytest.mark.parametrize(
@@ -48,3 +48,18 @@ def test_debian_architecture_to_platform_arch(given, expected):
 def test_debian_architecture_from_host(monkeypatch, machine):
     monkeypatch.setattr(platform, "machine", lambda: machine)
     assert DebianArchitecture.from_host().to_platform_arch() == machine
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        (str(DebianArchitecture.AMD64), (None, "amd64")),
+        (str(DebianArchitecture.RISCV64), (None, "riscv64")),
+        ("all", (None, "all")),
+        ("ubuntu@24.04:amd64", (DistroBase("ubuntu", "24.04"), "amd64")),
+        ("ubuntu@24.04:riscv64", (DistroBase("ubuntu", "24.04"), "riscv64")),
+        ("ubuntu@24.04:all", (DistroBase("ubuntu", "24.04"), "all")),
+    ],
+)
+def test_get_base_and_architecture(given, expected):
+    assert get_base_and_architecture(architecture=given) == expected

--- a/tests/unit/test_architectures.py
+++ b/tests/unit/test_architectures.py
@@ -18,7 +18,7 @@
 import platform
 
 import pytest
-from craft_platforms import DebianArchitecture, DistroBase, get_base_and_architecture
+from craft_platforms import DebianArchitecture, DistroBase, parse_base_and_architecture
 
 
 @pytest.mark.parametrize(
@@ -62,4 +62,4 @@ def test_debian_architecture_from_host(monkeypatch, machine):
     ],
 )
 def test_get_base_and_architecture(given, expected):
-    assert get_base_and_architecture(architecture=given) == expected
+    assert parse_base_and_architecture(arch=given) == expected

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -305,3 +305,17 @@ def test_build_plans_bad_base(base, error_msg):
 def test_build_plans_bad_architecture(platforms, error_msg):
     with pytest.raises(ValueError, match=error_msg):
         craft_platforms.get_platforms_build_plan("ubuntu@24.04", platforms)
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("my-platform", (None, "my-platform")),
+        (
+            "ubuntu@24.04:my-platform",
+            (craft_platforms.DistroBase("ubuntu", "24.04"), "my-platform"),
+        ),
+    ],
+)
+def test_get_base_and_name(given, expected):
+    assert craft_platforms.get_base_and_name(platform_name=given) == expected

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -318,4 +318,4 @@ def test_build_plans_bad_architecture(platforms, error_msg):
     ],
 )
 def test_get_base_and_name(given, expected):
-    assert craft_platforms.get_base_and_name(platform_name=given) == expected
+    assert craft_platforms.parse_base_and_name(platform_name=given) == expected

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -318,4 +318,4 @@ def test_build_plans_bad_architecture(platforms, error_msg):
     ],
 )
 def test_get_base_and_name(given, expected):
-    assert craft_platforms.parse_base_and_name(platform_name=given) == expected
+    assert craft_platforms.parse_base_and_name(given) == expected


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

-----

Adds multi-base support for charm build plans.

Documentation will be added in another PR (#70).

Issues I found into when working on this task:
- #79 
- #80
- #82

Fixes #73
(CRAFT-3721) (the branch name has the wrong number)