### PR TITLE
style: improve error message for invalid architectures

### DIFF
--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -90,6 +90,8 @@ def parse_base_and_architecture(
 
     :returns: A tuple of the DistroBase and the architecture. The architecture is either
      a DebianArchitecture or 'all'.
+
+    :raises ValueError: If the architecture or base is invalid.
     """
     if ":" in arch:
         base_str, _, arch_str = arch.partition(":")
@@ -98,4 +100,7 @@ def parse_base_and_architecture(
         base = None
         arch_str = arch
 
-    return base, DebianArchitecture(arch_str) if arch_str != "all" else "all"
+    try:
+        return base, DebianArchitecture(arch_str) if arch_str != "all" else "all"
+    except ValueError as err:
+        raise ValueError(f"{arch_str!r} is not a valid architecture.") from err

--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -102,5 +102,5 @@ def parse_base_and_architecture(
 
     try:
         return base, DebianArchitecture(arch_str) if arch_str != "all" else "all"
-    except ValueError as err:
-        raise ValueError(f"{arch_str!r} is not a valid architecture.") from err
+    except ValueError:
+        raise ValueError(f"{arch_str!r} is not a valid Debian architecture.") from None

--- a/craft_platforms/_platforms.py
+++ b/craft_platforms/_platforms.py
@@ -112,6 +112,8 @@ def parse_base_and_name(platform_name: str) -> Tuple[Optional[_distro.DistroBase
     :param platform_name: The name of the platform.
 
     :returns: A tuple of the DistroBase and the platform name.
+
+    :raises ValueError: If the base is invalid.
     """
     if ":" in platform_name:
         base_str, _, name = platform_name.partition(":")

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,8 +2,11 @@
 Changelog
 *********
 
-X.Y.Z (2025-MM-DD)
+0.6.0 (2025-MM-DD)
 ------------------
+
+Features
+========
 
 - Improve presentation of invalid architecture error messages.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 *********
 
+X.Y.Z (2025-MM-DD)
+------------------
+
+- Improve presentation of invalid architecture error messages.
+
 0.5.0 (2024-12-18)
 ------------------
 

--- a/tests/unit/charm/test_build.py
+++ b/tests/unit/charm/test_build.py
@@ -510,7 +510,7 @@ def test_build_plans_bad_base(base, build_base, platforms, error_msg, error_res)
         ),
         pytest.param(
             {"my machine": {"build-on": ["my machine"], "build-for": ["amd64"]}},
-            "'my machine' is not a valid architecture",
+            "'my machine' is not a valid Debian architecture",
             id="invalid-architecture-name",
         ),
         pytest.param(

--- a/tests/unit/charm/test_build.py
+++ b/tests/unit/charm/test_build.py
@@ -510,7 +510,7 @@ def test_build_plans_bad_base(base, build_base, platforms, error_msg, error_res)
         ),
         pytest.param(
             {"my machine": {"build-on": ["my machine"], "build-for": ["amd64"]}},
-            "'my machine' is not a valid DebianArchitecture",
+            "'my machine' is not a valid architecture",
             id="invalid-architecture-name",
         ),
         pytest.param(

--- a/tests/unit/test_architectures.py
+++ b/tests/unit/test_architectures.py
@@ -61,5 +61,21 @@ def test_debian_architecture_from_host(monkeypatch, machine):
         ("ubuntu@24.04:all", (DistroBase("ubuntu", "24.04"), "all")),
     ],
 )
-def test_get_base_and_architecture(given, expected):
+def test_parse_base_and_architecture(given, expected):
     assert parse_base_and_architecture(given) == expected
+
+
+def test_parse_base_and_architecture_invalid_arch():
+    expected = "'unknown' is not a valid Debian architecture."
+
+    with pytest.raises(ValueError, match=expected):
+        parse_base_and_architecture("unknown")
+
+
+def test_parse_base_and_architecture_invalid_base():
+    expected = (
+        "Invalid base string 'unknown'. Format should be '<distribution>@<series>'"
+    )
+
+    with pytest.raises(ValueError, match=expected):
+        parse_base_and_architecture("unknown:riscv64")

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -317,5 +317,14 @@ def test_build_plans_bad_architecture(platforms, error_msg):
         ),
     ],
 )
-def test_get_base_and_name(given, expected):
+def test_parse_base_and_name(given, expected):
     assert craft_platforms.parse_base_and_name(given) == expected
+
+
+def test_parse_base_and_name_invalid_base():
+    expected = (
+        "Invalid base string 'unknown'. Format should be '<distribution>@<series>'"
+    )
+
+    with pytest.raises(ValueError, match=expected):
+        craft_platforms.parse_base_and_name("unknown:my-platform")


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

-----

Update docstrings to include `:raises:`, improve error message presentation.

Fixes https://github.com/canonical/craft-application/issues/629#issuecomment-2628125808