### PR TITLE
fix: pass snap type to obtain the snapcraft build plan

### DIFF
--- a/craft_platforms/_build.py
+++ b/craft_platforms/_build.py
@@ -48,8 +48,13 @@ def get_build_plan(
     """
     planner = _APP_SPECIFIC_PLANNERS.get(app, get_platforms_build_plan)
 
-    return planner(
-        base=project_data.get("base"),
-        platforms=project_data.get("platforms"),
-        build_base=project_data.get("build-base"),
-    )
+    args = {
+        "base": project_data.get("base"),
+        "platforms": project_data.get("platforms"),
+        "build_base": project_data.get("build-base"),
+    }
+
+    if app == "snapcraft":
+        args["snap_type"] = project_data.get("type")
+
+    return planner(**args)

--- a/craft_platforms/snap/_build.py
+++ b/craft_platforms/snap/_build.py
@@ -186,7 +186,7 @@ def get_platforms_snap_build_plan(
     snap_type: Optional[str] = None,
     platforms: Union[_platforms.Platforms, None],
 ) -> Sequence[_buildinfo.BuildInfo]:
-    """Generate the build plan for a platforms-based charm.
+    """Generate the build plan for a platforms-based snap.
 
     :param base: The ``base`` string in ``snapcraft.yaml`` (or ``None`` if not given)
     :param build_base: The ``build-base`` string in ``snapcraft.yaml`` (or ``None`` if

--- a/tests/integration/valid-projects/snapcraft-3.yaml
+++ b/tests/integration/valid-projects/snapcraft-3.yaml
@@ -1,0 +1,18 @@
+name: core24
+summary: test for build plan with snap type
+description: test for build plan with snap type
+confinement: strict
+type: base
+build-base: core24
+grade: stable
+assumes: [snapd2.55.5]
+
+platforms:
+  amd64:
+
+parts:
+  base:
+    plugin: nil
+
+_build_plan:
+  - "BuildInfo(platform='amd64', build_on=DebianArchitecture('amd64'), build_for=DebianArchitecture('amd64'), build_base=DistroBase(distribution='ubuntu', series='24.04'))"

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -1,0 +1,38 @@
+# This file is part of craft-platforms.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for build functions."""
+
+import pytest
+from craft_platforms import _build
+
+from unittest.mock import Mock, call
+
+
+def test_get_snapcraft_build_plan(monkeypatch):
+    fake_build_plan = Mock()
+    monkeypatch.setitem(_build._APP_SPECIFIC_PLANNERS, "snapcraft", fake_build_plan)
+
+    project_data = {
+        "base": "core22",
+        "build-base": "core24",
+        "platforms": {},
+        "type": "base",
+    }
+    _build.get_build_plan("snapcraft", project_data=project_data)
+
+    assert fake_build_plan.mock_calls == [
+        call(base="core22", build_base="core24", platforms={}, snap_type="base")
+    ]


### PR DESCRIPTION
Applications can supply different parameters when computing the build
plan. Snapcraft requires the `snap_type` parameter to set.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

-----
