### PR TITLE
relax setuptools requirement to >=61.0 for Launchpad compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ constraint-dependencies = [
 
 [build-system]
 requires = [
-    "setuptools>=69.0",
+    "setuptools>=61.0",
     "setuptools_scm[toml]>=7.1"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ constraint-dependencies = [
 
 [build-system]
 requires = [
-    "setuptools>=61.0",
+    "setuptools>=61.0",  # check with Launchpad before increasing this 
     "setuptools_scm[toml]>=7.1"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

This change lowers the setuptools requirement in pyproject.toml from >=69.0 to >=61.0. Launchpad current build environment uses setuptools==61.x, and requiring setuptools>=69.0 breaks some other dependencies, as it conflicts with other pinned packages.

Updating the requirement to >=61.0 allows craft-platforms to be used along all other dependencies in Launchpad.