### PR TITLE
feat(rock): support Rockcraft legacy base names

### DIFF
--- a/craft_platforms/rock/_build.py
+++ b/craft_platforms/rock/_build.py
@@ -19,6 +19,11 @@ from typing import Optional, Sequence
 
 from craft_platforms import _buildinfo, _errors, _platforms
 
+_LEGACY_BASES_MAP = {
+    "ubuntu:20.04": "ubuntu@20.04",
+    "ubuntu:22.04": "ubuntu@22.04",
+}
+
 
 def get_rock_build_plan(
     base: str,
@@ -38,6 +43,11 @@ def get_rock_build_plan(
     # Bare bases require a build_base
     if base == "bare" and build_base is None:
         raise _errors.NeedBuildBaseError(base=base)
+
+    if base in _LEGACY_BASES_MAP:
+        base = _LEGACY_BASES_MAP[base]
+    if build_base in _LEGACY_BASES_MAP:
+        build_base = _LEGACY_BASES_MAP[build_base]
 
     for name, platform in platforms.items():
         if platform and "all" in platform.get("build-for", []):

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,7 +2,16 @@
 Changelog
 *********
 
+0.8.0 (2025-04-16)
+------------------
+
+Features
+========
+
+- Legacy rockcraft base strings ``ubuntu:20.04`` and ``ubuntu:22.04`` are supported.
+
 0.7.1 (2025-04-10)
+------------------
 
 Bug Fixes
 =========

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 Features
 ========
 
-- Legacy rockcraft base strings ``ubuntu:20.04`` and ``ubuntu:22.04`` are supported.
+- Legacy rockcraft base strings ``ubuntu:20.04`` and ``ubuntu:22.04`` are now supported.
 
 0.7.1 (2025-04-10)
 ------------------

--- a/tests/integration/valid-projects/rockcraft-legacy-focal.yaml
+++ b/tests/integration/valid-projects/rockcraft-legacy-focal.yaml
@@ -1,0 +1,25 @@
+name: legacy-2004
+base: ubuntu:20.04
+
+version: "0.1"
+summary: A rock that bundles a Python project.
+description: A rock that bundles a Python project.
+license: GPL-3.0
+platforms:
+  amd64:
+
+parts:
+  python-sample:
+    plugin: python
+    source: src
+    python-packages: [black]
+    stage-packages: [python3-venv, python3-cpuinfo]
+
+  check-pythonpath:
+    plugin: dump
+    source: src
+    stage:
+      - check-pythonpath.py
+
+_build_plan:
+  - "BuildInfo(platform='amd64', build_on=DebianArchitecture('amd64'), build_for=DebianArchitecture('amd64'), build_base=DistroBase(distribution='ubuntu', series='20.04'))"

--- a/tests/integration/valid-projects/rockcraft-legacy-jammy.yaml
+++ b/tests/integration/valid-projects/rockcraft-legacy-jammy.yaml
@@ -1,0 +1,25 @@
+name: legacy-2204
+base: ubuntu:22.04
+
+version: "0.1"
+summary: A rock that bundles a Python project.
+description: A rock that bundles a Python project.
+license: GPL-3.0
+platforms:
+  amd64:
+
+parts:
+  python-sample:
+    plugin: python
+    source: src
+    python-packages: [black]
+    stage-packages: [python3-venv, python3-cpuinfo]
+
+  check-pythonpath:
+    plugin: dump
+    source: src
+    stage:
+      - check-pythonpath.py
+
+_build_plan:
+  - "BuildInfo(platform='amd64', build_on=DebianArchitecture('amd64'), build_for=DebianArchitecture('amd64'), build_base=DistroBase(distribution='ubuntu', series='22.04'))"

--- a/tests/unit/rock/test_build.py
+++ b/tests/unit/rock/test_build.py
@@ -42,6 +42,11 @@ SAMPLE_UBUNTU_VERSIONS = ("16.04", "18.04", "20.04", "22.04", "24.04", "24.10", 
             )
             for version in SAMPLE_UBUNTU_VERSIONS
         ],
+        # Legacy base strings containing colons
+        ("ubuntu:20.04", None, craft_platforms.DistroBase.from_str("ubuntu@20.04")),
+        ("ubuntu:22.04", None, craft_platforms.DistroBase.from_str("ubuntu@22.04")),
+        ("bare", "ubuntu:20.04", craft_platforms.DistroBase.from_str("ubuntu@20.04")),
+        ("bare", "ubuntu:22.04", craft_platforms.DistroBase.from_str("ubuntu@22.04")),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds support for the legacy base names "ubuntu:20.04" and "ubuntu:22.04" to the Rockcraft build planner. These are needed because the "@" convention was only standardised after Rockcraft included these.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

ROCKCRAFT-225