### PR TITLE
style: fix linting errors for ruff 0.12

### DIFF
--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import enum
 import platform
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal, Tuple, Union
 
 from typing_extensions import Self
 
@@ -89,7 +89,7 @@ _ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
 
 def parse_base_and_architecture(
     arch: str,
-) -> Tuple[Optional[_distro.DistroBase], Union[DebianArchitecture, Literal["all"]]]:
+) -> Tuple[_distro.DistroBase | None, Union[DebianArchitecture, Literal["all"]]]:
     """Get the debian arch and optional base from an architecture entry.
 
     The architecture may have an optional base prefixed as '[<base>:]<arch>'.

--- a/craft_platforms/_distro.py
+++ b/craft_platforms/_distro.py
@@ -81,8 +81,8 @@ def _is_distrobase_compatible(item: object) -> bool:
     )
 
 
-@dataclasses.dataclass(repr=True)
-class DistroBase:
+@dataclasses.dataclass(repr=True, frozen=True)
+class DistroBase:  # noqa: PLW1641 (https://github.com/astral-sh/ruff/issues/18905)
     """A linux distribution base."""
 
     distribution: str

--- a/craft_platforms/_errors.py
+++ b/craft_platforms/_errors.py
@@ -33,8 +33,8 @@ class CraftError(typing.Protocol):
     resolution: Optional[str]
 
 
-@dataclasses.dataclass()
-class CraftPlatformsError(Exception):
+@dataclasses.dataclass(unsafe_hash=True)
+class CraftPlatformsError(Exception):  # noqa: PLW1641 (https://github.com/astral-sh/ruff/issues/18905)
     """Signal a program error with a lot of information to report."""
 
     message: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,6 @@ strict = false
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
 src = ["craft_platforms", "tests"]
 extend-exclude = [
     "docs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def project_main_module() -> types.ModuleType:
     downstream project.
     """
     try:
-        import craft_platforms
+        import craft_platforms  # noqa: PLC0415
 
         main_module = craft_platforms
     except ImportError:


### PR DESCRIPTION
Ruff 0.12 made PLC0415 and PLW1641 stable. For PLW1641 this uncovered a bug (https://github.com/astral-sh/ruff/issues/18905), for PLC0415 we simply need to ignore it.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
