### PR TITLE
feat(charm): add a build planner for bases charms

### DIFF
--- a/craft_platforms/_build.py
+++ b/craft_platforms/_build.py
@@ -22,7 +22,7 @@ from craft_platforms._buildinfo import BuildInfo
 from craft_platforms._platforms import get_platforms_build_plan
 
 _APP_SPECIFIC_PLANNERS: Dict[str, Callable[..., Iterable[BuildInfo]]] = {
-    "charmcraft": charm.get_platforms_charm_build_plan,
+    "charmcraft": charm.get_charm_build_plan,
     "rockcraft": rock.get_rock_build_plan,
     "snapcraft": snap.get_platforms_snap_build_plan,
 }
@@ -47,6 +47,8 @@ def get_build_plan(
     planners or special behaviour for more apps.
     """
     planner = _APP_SPECIFIC_PLANNERS.get(app, get_platforms_build_plan)
+    if app == "charmcraft":
+        return planner(project_data)
 
     args = {
         "base": project_data.get("base"),

--- a/craft_platforms/charm/__init__.py
+++ b/craft_platforms/charm/__init__.py
@@ -15,10 +15,17 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Charm-specific module for craft-platforms."""
 
-from ._build import DEFAULT_ARCHITECTURES, get_platforms_charm_build_plan
+from ._build import (
+    DEFAULT_ARCHITECTURES,
+    get_platforms_charm_build_plan,
+    get_bases_charm_build_plan,
+    get_charm_build_plan,
+)
 
 
 __all__ = [
     "DEFAULT_ARCHITECTURES",
     "get_platforms_charm_build_plan",
+    "get_bases_charm_build_plan",
+    "get_charm_build_plan",
 ]

--- a/craft_platforms/charm/_build.py
+++ b/craft_platforms/charm/_build.py
@@ -16,7 +16,7 @@
 """Charmcraft-specific platforms information."""
 
 import itertools
-from typing import Collection, List, Optional, Sequence
+from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence
 
 from craft_platforms import (
     _architectures,
@@ -279,3 +279,49 @@ def get_platforms_charm_build_plan(
                 )
 
     return build_plan
+
+
+def _gen_build_plan_for_base(base: Dict[str, Any]) -> Iterable[_buildinfo.BuildInfo]:
+    if "build-on" not in base:
+        base = {"build-on": [base], "run-on": [base]}
+
+    for build_base in base["build-on"]:
+        for run_base in base["run-on"]:
+            build_archs = build_base.get("architectures", DEFAULT_ARCHITECTURES)
+            for build_arch in build_archs:
+                run_archs = run_base.get("architectures", [build_arch])
+                run_archs_str = "-".join(run_archs)
+                yield _buildinfo.BuildInfo(
+                    f"{build_base['name']}-{build_base['channel']}-{run_archs_str}",
+                    build_on=_architectures.DebianArchitecture(build_arch),
+                    build_for=run_archs[0],
+                    build_base=_distro.DistroBase(
+                        build_base["name"], build_base["channel"]
+                    ),
+                )
+
+
+def get_bases_charm_build_plan(
+    bases: Sequence[Dict[str, Any]],
+) -> Sequence[_buildinfo.BuildInfo]:
+    """Get a build plan for a legacy "bases" based charm."""
+    plan = []
+    for base in bases:
+        plan.extend(_gen_build_plan_for_base(base))
+    return plan
+
+
+def get_charm_build_plan(
+    project_data: Dict[str, Any],
+) -> Sequence[_buildinfo.BuildInfo]:
+    if "platforms" in project_data:
+        return get_platforms_charm_build_plan(
+            base=project_data.get("base"),
+            build_base=project_data.get("build-base"),
+            platforms=project_data.get(
+                "platforms",
+            ),
+        )
+    if "bases" in project_data:
+        return get_bases_charm_build_plan(project_data["bases"])
+    raise NotImplementedError("Unknown charm type with no bases or platforms.")

--- a/craft_platforms/charm/_build.py
+++ b/craft_platforms/charm/_build.py
@@ -305,7 +305,7 @@ def get_bases_charm_build_plan(
     bases: Sequence[Dict[str, Any]],
 ) -> Sequence[_buildinfo.BuildInfo]:
     """Get a build plan for a legacy "bases" based charm."""
-    plan = []
+    plan: List[_buildinfo.BuildInfo] = []
     for base in bases:
         plan.extend(_gen_build_plan_for_base(base))
     return plan

--- a/craft_platforms/charm/_build.py
+++ b/craft_platforms/charm/_build.py
@@ -286,19 +286,18 @@ def _gen_build_plan_for_base(base: Dict[str, Any]) -> Iterable[_buildinfo.BuildI
         base = {"build-on": [base], "run-on": [base]}
 
     for build_base in base["build-on"]:
-        for run_base in base["run-on"]:
-            build_archs = build_base.get("architectures", DEFAULT_ARCHITECTURES)
-            for build_arch in build_archs:
-                run_archs = run_base.get("architectures", [build_arch])
-                run_archs_str = "-".join(run_archs)
-                yield _buildinfo.BuildInfo(
-                    f"{build_base['name']}-{build_base['channel']}-{run_archs_str}",
-                    build_on=_architectures.DebianArchitecture(build_arch),
-                    build_for=run_archs[0],
-                    build_base=_distro.DistroBase(
-                        build_base["name"], build_base["channel"]
-                    ),
-                )
+        build_archs = build_base.get("architectures", DEFAULT_ARCHITECTURES)
+        for run_base, build_arch in itertools.product(base["run-on"], build_archs):
+            run_archs = run_base.get("architectures", [build_arch])
+            run_archs_str = "-".join(run_archs)
+            yield _buildinfo.BuildInfo(
+                f"{build_base['name']}-{build_base['channel']}-{run_archs_str}",
+                build_on=_architectures.DebianArchitecture(build_arch),
+                build_for=run_archs[0],
+                build_base=_distro.DistroBase(
+                    build_base["name"], build_base["channel"]
+                ),
+            )
 
 
 def get_bases_charm_build_plan(

--- a/tests/integration/valid-projects/charmcraft-bases-basic.yaml
+++ b/tests/integration/valid-projects/charmcraft-bases-basic.yaml
@@ -1,0 +1,19 @@
+name: example-charm
+summary: An example charm with the legacy bases keyword
+description: |
+  A description for an example charm with the legacy bases keyword.
+type: charm
+bases:
+  - name: ubuntu
+    channel: "22.04"
+
+parts:
+  charm:
+    plugin: charm
+
+_build_plan:
+  - "BuildInfo(platform='ubuntu-22.04-amd64', build_on='amd64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-arm64', build_on='arm64', build_for='arm64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-ppc64el', build_on='ppc64el', build_for='ppc64el', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-riscv64', build_on='riscv64', build_for='riscv64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-s390x', build_on='s390x', build_for='s390x', build_base=DistroBase(distribution='ubuntu', series='22.04'))"

--- a/tests/integration/valid-projects/charmcraft-bases-complex.yaml
+++ b/tests/integration/valid-projects/charmcraft-bases-complex.yaml
@@ -1,0 +1,62 @@
+name: example-charm
+summary: An example charm with the legacy bases keyword
+description: |
+  A description for an example charm with the legacy bases keyword.
+type: charm
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures:
+          - amd64
+          - riscv64
+      - name: ubuntu
+        channel: "20.04"
+        architectures:
+          - amd64
+          - arm64
+    run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures:
+          - amd64
+      - name: ubuntu
+        channel: "22.04"
+        architectures:
+          - riscv64
+      - name: ubuntu
+        channel: "22.04"
+        architectures:
+          - arm64
+  - build-on:
+      - name: ubuntu
+        channel: "20.04"
+    run-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures:
+          - amd64
+          - arm64
+          - riscv64
+          - s390x
+          - ppc64el
+          - armhf
+
+_build_plan:
+  - "BuildInfo(platform='ubuntu-22.04-amd64', build_on='amd64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-amd64', build_on='riscv64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-riscv64', build_on='amd64', build_for='riscv64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-riscv64', build_on='riscv64', build_for='riscv64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-arm64', build_on='amd64', build_for='arm64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-22.04-arm64', build_on='riscv64', build_for='arm64', build_base=DistroBase(distribution='ubuntu', series='22.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-amd64', build_on='amd64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-amd64', build_on='arm64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-riscv64', build_on='amd64', build_for='riscv64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-riscv64', build_on='arm64', build_for='riscv64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-arm64', build_on='amd64', build_for='arm64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-arm64', build_on='arm64', build_for='arm64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf', build_on='amd64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf', build_on='arm64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf', build_on='ppc64el', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf', build_on='riscv64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"
+  - "BuildInfo(platform='ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf', build_on='s390x', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"

--- a/tests/unit/charm/test_build.py
+++ b/tests/unit/charm/test_build.py
@@ -677,3 +677,299 @@ def test_fuzz_get_platforms_build_plan_multi_base(
 ):
     assume(_is_valid_platform(platforms))
     craft_platforms.charm.get_platforms_charm_build_plan(None, platforms)
+
+
+@pytest.mark.parametrize(
+    ("bases", "expected"),
+    [
+        pytest.param(
+            [{"name": "ubuntu", "channel": "20.04"}],
+            [
+                craft_platforms.BuildInfo(
+                    "ubuntu-20.04-amd64",
+                    craft_platforms.DebianArchitecture.AMD64,
+                    craft_platforms.DebianArchitecture.AMD64,
+                    craft_platforms.DistroBase("ubuntu", "20.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "ubuntu-20.04-arm64",
+                    craft_platforms.DebianArchitecture.ARM64,
+                    craft_platforms.DebianArchitecture.ARM64,
+                    craft_platforms.DistroBase("ubuntu", "20.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "ubuntu-20.04-ppc64el",
+                    craft_platforms.DebianArchitecture.PPC64EL,
+                    craft_platforms.DebianArchitecture.PPC64EL,
+                    craft_platforms.DistroBase("ubuntu", "20.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "ubuntu-20.04-riscv64",
+                    craft_platforms.DebianArchitecture.RISCV64,
+                    craft_platforms.DebianArchitecture.RISCV64,
+                    craft_platforms.DistroBase("ubuntu", "20.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "ubuntu-20.04-s390x",
+                    craft_platforms.DebianArchitecture.S390X,
+                    craft_platforms.DebianArchitecture.S390X,
+                    craft_platforms.DistroBase("ubuntu", "20.04"),
+                ),
+            ],
+        ),
+        pytest.param(
+            [{"name": "ubuntu", "channel": "22.04", "architectures": ["arm64"]}],
+            [
+                craft_platforms.BuildInfo(
+                    "ubuntu-22.04-arm64",
+                    craft_platforms.DebianArchitecture.ARM64,
+                    craft_platforms.DebianArchitecture.ARM64,
+                    craft_platforms.DistroBase("ubuntu", "22.04"),
+                ),
+            ],
+        ),
+        pytest.param(
+            [
+                {
+                    "build-on": [
+                        {
+                            "name": "ubuntu",
+                            "channel": "22.04",
+                            "architectures": ["amd64", "s390x"],
+                        }
+                    ],
+                    "run-on": [
+                        {
+                            "name": "ubuntu",
+                            "channel": "22.04",
+                            "architectures": ["s390x"],
+                        }
+                    ],
+                },
+            ],
+            [
+                craft_platforms.BuildInfo(
+                    "ubuntu-22.04-s390x",
+                    craft_platforms.DebianArchitecture.AMD64,
+                    craft_platforms.DebianArchitecture.S390X,
+                    craft_platforms.DistroBase("ubuntu", "22.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "ubuntu-22.04-s390x",
+                    craft_platforms.DebianArchitecture.S390X,
+                    craft_platforms.DebianArchitecture.S390X,
+                    craft_platforms.DistroBase("ubuntu", "22.04"),
+                ),
+            ],
+        ),
+        pytest.param(
+            [
+                {
+                    "build-on": [
+                        {
+                            "name": "ubuntu",
+                            "channel": "22.04",
+                            "architectures": ["amd64", "riscv64"],
+                        },
+                        {
+                            "name": "ubuntu",
+                            "channel": "20.04",
+                            "architectures": ["amd64", "arm64"],
+                        },
+                    ],
+                    "run-on": [
+                        {
+                            "name": "ubuntu",
+                            "channel": "22.04",
+                            "architectures": ["amd64"],
+                        },
+                        {
+                            "name": "ubuntu",
+                            "channel": "22.04",
+                            "architectures": ["riscv64"],
+                        },
+                        {
+                            "name": "ubuntu",
+                            "channel": "22.04",
+                            "architectures": ["arm64"],
+                        },
+                    ],
+                },
+                {
+                    "build-on": [{"name": "ubuntu", "channel": "20.04"}],
+                    "run-on": [
+                        {
+                            "name": "ubuntu",
+                            "channel": "20.04",
+                            "architectures": [
+                                "amd64",
+                                "arm64",
+                                "riscv64",
+                                "s390x",
+                                "ppc64el",
+                                "armhf",
+                            ],
+                        }
+                    ],
+                },
+            ],
+            [
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-22.04-amd64",
+                    build_on=craft_platforms.DebianArchitecture.AMD64,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="22.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-22.04-amd64",
+                    build_on=craft_platforms.DebianArchitecture.RISCV64,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="22.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-22.04-riscv64",
+                    build_on=craft_platforms.DebianArchitecture.AMD64,
+                    build_for=craft_platforms.DebianArchitecture.RISCV64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="22.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-22.04-riscv64",
+                    build_on=craft_platforms.DebianArchitecture.RISCV64,
+                    build_for=craft_platforms.DebianArchitecture.RISCV64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="22.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-22.04-arm64",
+                    build_on=craft_platforms.DebianArchitecture.AMD64,
+                    build_for=craft_platforms.DebianArchitecture.ARM64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="22.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-22.04-arm64",
+                    build_on=craft_platforms.DebianArchitecture.RISCV64,
+                    build_for=craft_platforms.DebianArchitecture.ARM64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="22.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-amd64",
+                    build_on=craft_platforms.DebianArchitecture.AMD64,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-amd64",
+                    build_on=craft_platforms.DebianArchitecture.ARM64,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-riscv64",
+                    build_on=craft_platforms.DebianArchitecture.AMD64,
+                    build_for=craft_platforms.DebianArchitecture.RISCV64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-riscv64",
+                    build_on=craft_platforms.DebianArchitecture.ARM64,
+                    build_for=craft_platforms.DebianArchitecture.RISCV64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-arm64",
+                    build_on=craft_platforms.DebianArchitecture.AMD64,
+                    build_for=craft_platforms.DebianArchitecture.ARM64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-arm64",
+                    build_on=craft_platforms.DebianArchitecture.ARM64,
+                    build_for=craft_platforms.DebianArchitecture.ARM64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf",
+                    build_on=craft_platforms.DebianArchitecture.AMD64,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf",
+                    build_on=craft_platforms.DebianArchitecture.ARM64,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf",
+                    build_on=craft_platforms.DebianArchitecture.PPC64EL,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf",
+                    build_on=craft_platforms.DebianArchitecture.RISCV64,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+                craft_platforms.BuildInfo(
+                    platform="ubuntu-20.04-amd64-arm64-riscv64-s390x-ppc64el-armhf",
+                    build_on=craft_platforms.DebianArchitecture.S390X,
+                    build_for=craft_platforms.DebianArchitecture.AMD64,
+                    build_base=craft_platforms.DistroBase(
+                        distribution="ubuntu",
+                        series="20.04",
+                    ),
+                ),
+            ],
+        ),
+    ],
+)
+def test_bases_build_plan_success(bases, expected):
+    assert charm.get_bases_charm_build_plan(bases) == expected


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Adds a build planner for legacy charms that use the `bases` key.

CHARMCRAFT-630