### PR TITLE
style: fix docstring line breaks

### DIFF
--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -73,8 +73,7 @@ class DebianArchitecture(str, enum.Enum):
     def to_efi_arch(self) -> str:
         """Convert this DebianArchitecture to an EFI firmware string.
 
-        :returns: A string as matched by UKIFY in systemd
-        (see https://github.com/systemd/systemd/blob/main/src/ukify/ukify.py)
+        :returns: A string as matched by UKIFY in systemd (see https://github.com/systemd/systemd/blob/main/src/ukify/ukify.py)
         """
         return _ARCH_TRANSLATIONS_DEB_TO_EFI.get(self.value, self.value)
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
A line break in a docstring was causing the docs task to fail in CI (https://github.com/canonical/craft-platforms/actions/runs/17474601595/job/49631158084). I'm not sure why this wasn't caught in CI for #153.