### PR TITLE
feat!(platform): make 'any' and '*' invalid platform names

### DIFF
--- a/craft_platforms/_errors.py
+++ b/craft_platforms/_errors.py
@@ -148,6 +148,10 @@ class NeedBuildBaseError(CraftPlatformsError, ValueError):
 
 
 class InvalidPlatformNameError(CraftPlatformsError, ValueError):
+    """Error when a specified platform name is invalid."""
+
+
+class InvalidDebianArchPlatformNameError(InvalidPlatformNameError):
     """Error when a specified platform name is not a Debian architecture."""
 
     def __init__(self, platform_name: str) -> None:

--- a/craft_platforms/charm/_build.py
+++ b/craft_platforms/charm/_build.py
@@ -221,6 +221,22 @@ def get_platforms_charm_build_plan(
             )
             for arch in DEFAULT_ARCHITECTURES
         ]
+
+    used_reserved_names = _platforms.RESERVED_PLATFORM_NAMES & platforms.keys()
+    if used_reserved_names:
+        if len(used_reserved_names) == 1:
+            raise _errors.InvalidPlatformNameError(
+                f"Platform name {next(iter(used_reserved_names))!r} is reserved.",
+                resolution="Use a different platform name, perhaps 'all' for platform-agnostic artifacts.",
+            )
+        used_reserved_names_str = ", ".join(
+            f"{name!r}" for name in sorted(used_reserved_names)
+        )
+        raise _errors.InvalidPlatformNameError(
+            f"Reserved platform names used: {used_reserved_names_str}",
+            resolution="Change the platform name strings for these platforms.",
+        )
+
     build_plan: List[_buildinfo.BuildInfo] = []
     for platform_name, platform in platforms.items():
         distro_base = _get_base_from_build_data(

--- a/craft_platforms/test/strategies.py
+++ b/craft_platforms/test/strategies.py
@@ -17,6 +17,8 @@
 
 from typing import Dict, Optional, Union
 
+from craft_platforms._platforms import RESERVED_PLATFORM_NAMES
+
 try:
     from hypothesis import strategies
 except ImportError:
@@ -306,7 +308,9 @@ def platform(
             max_size=1,
         ),
         strategies.dictionaries(
-            keys=strategies.text(min_size=1).filter(lambda x: x not in ("@", ":")),
+            keys=strategies.text(min_size=1).filter(
+                lambda x: x not in ("@", ":", *RESERVED_PLATFORM_NAMES)
+            ),
             values=values,
             min_size=1,
             max_size=1,

--- a/tests/integration/invalid-platform-names/charmcraft-any.yaml
+++ b/tests/integration/invalid-platform-names/charmcraft-any.yaml
@@ -1,0 +1,8 @@
+name: example-charm
+summary: An example charm with platforms
+description: |
+  A description for an example charm with platforms.
+type: charm
+base: ubuntu@22.04
+platforms:
+  any:

--- a/tests/integration/invalid-platform-names/rockcraft-any.yaml
+++ b/tests/integration/invalid-platform-names/rockcraft-any.yaml
@@ -1,0 +1,25 @@
+name: base-2004
+base: ubuntu@20.04
+
+version: "0.1"
+summary: A rock that bundles a Python project.
+description: A rock that bundles a Python project.
+license: GPL-3.0
+platforms:
+  any:
+
+parts:
+  python-sample:
+    plugin: python
+    source: src
+    python-packages: [black]
+    stage-packages: [python3-venv, python3-cpuinfo]
+
+  check-pythonpath:
+    plugin: dump
+    source: src
+    stage:
+      - check-pythonpath.py
+
+_build_plan:
+  - "BuildInfo(platform='amd64', build_on='amd64', build_for='amd64', build_base=DistroBase(distribution='ubuntu', series='20.04'))"

--- a/tests/integration/invalid-platform-names/snapcraft-any.yaml
+++ b/tests/integration/invalid-platform-names/snapcraft-any.yaml
@@ -1,0 +1,16 @@
+name: hello-try
+base: core24
+version: "0.1"
+summary: snapcraft try spread test
+description: snapcraft try spread test
+
+grade: stable
+confinement: strict
+platforms:
+  any:
+    build-on: [amd64, arm64]
+    build-for: any
+
+parts:
+  hello-part:
+    plugin: nil

--- a/tests/integration/invalid-platform-names/testcraft-any.yaml
+++ b/tests/integration/invalid-platform-names/testcraft-any.yaml
@@ -1,0 +1,3 @@
+base: ubuntu@26.10
+platforms:
+  any:

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -18,6 +18,7 @@ import pathlib
 import craft_platforms
 import pytest
 import yaml
+from craft_platforms._errors import InvalidPlatformNameError
 
 
 @pytest.mark.parametrize(
@@ -37,3 +38,23 @@ def test_valid_projects_succeed(filename: str) -> None:
     expected = project_data["_build_plan"]
 
     assert [repr(item) for item in build_plan] == expected
+
+
+@pytest.mark.parametrize(
+    ("filename"),
+    [
+        path.name
+        for path in (pathlib.Path(__file__).parent / "invalid-platform-names").iterdir()
+    ],
+)
+def test_invalid_platform_names(filename: str) -> None:
+    app_name = filename.partition("-")[0]
+    with (
+        pathlib.Path(__file__).parent / "invalid-platform-names" / filename
+    ).open() as f:
+        project_data = yaml.safe_load(f)
+
+    with pytest.raises(
+        InvalidPlatformNameError, match="Platform name '.*' is reserved."
+    ):
+        craft_platforms.get_build_plan(app=app_name, project_data=project_data)


### PR DESCRIPTION
Also creates a way to reserve other platform names.

Fixes #166
CRAFT-4746

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
