### PR TITLE
chore: remove authors from changelog codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,8 @@
 *.py    @lengau
 
 # Documentation owners
-/docs/reference/changelog.rst @canonical/starcraft-reviewers
 /docs/  @canonical/starcraft-authors
+/docs/reference/changelog.rst @canonical/starcraft-reviewers
 
 # Module-specific overrides to match application ownership.
 /craft_platforms/charm  @lengau


### PR DESCRIPTION
Having the authors own the changelog is a heavy burden for them in our libraries that's minimally useful.

Per @medubelko, from now on, TA reviews for the changelog are opt-in when we decide we need their input.

Drive-by: changes docs ownership in general to the authors group

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
