### PR TITLE
fix(charm): accept redundant multi-base charms

### DIFF
--- a/craft_platforms/charm/_build.py
+++ b/craft_platforms/charm/_build.py
@@ -40,7 +40,7 @@ If no platforms are defined, the charm will be built on and for these architectu
 """
 
 
-def _validate_base_definition(
+def _validate_base_definition(  # noqa: PLR0912
     base: Optional[str],
     build_base: Optional[str],
     platform_name: Optional[str],
@@ -68,16 +68,24 @@ def _validate_base_definition(
 
     if platform:
         if platform_base:
-            raise _errors.InvalidMultiBaseError(
-                message=(
-                    f"Platform {platform_name!r} declares a base in the platform's "
-                    "name and declares 'build-on' and 'build-for' entries."
-                ),
-                resolution=(
-                    "Either remove the base from the platform's name or remove the "
-                    "'build-on' and 'build-for' entries for the platform."
-                ),
-            )
+            build_for_bases = [
+                _architectures.parse_base_and_architecture(target_base)[0]
+                for target_base in platform.get("build-for", [platform_name])
+            ]
+            for check_base in build_for_bases:
+                if check_base in (None, platform_base):
+                    continue
+                raise _errors.InvalidMultiBaseError(
+                    message=(
+                        f"Platform {platform_name!r} declares a base in the "
+                        "platform's name and declares an incompatible 'build-for' "
+                        f"entry ({check_base})."
+                    ),
+                    resolution=(
+                        "Either remove the base from the platform's name or remove "
+                        "the incompatible 'build-for' entry for the platform."
+                    ),
+                )
         # create a set of the bases defined in the build-on and build-for entries
         bases = set()
         for entry in [

--- a/craft_platforms/charm/_build.py
+++ b/craft_platforms/charm/_build.py
@@ -89,8 +89,8 @@ def _validate_base_definition(  # noqa: PLR0912
         # create a set of the bases defined in the build-on and build-for entries
         bases = set()
         for entry in [
-            *_utils.vectorize(platform["build-on"]),
-            *_utils.vectorize(platform["build-for"]),
+            *_utils.vectorize(platform.get("build-on", [platform_name])),
+            *_utils.vectorize(platform.get("build-for", [platform_name])),
         ]:
             distro_base, _ = _architectures.parse_base_and_architecture(arch=entry)
             bases.add(str(distro_base) if distro_base else None)
@@ -278,8 +278,8 @@ def get_platforms_charm_build_plan(
             )
         else:
             for build_on, build_for in itertools.product(
-                _utils.vectorize(platform["build-on"]),
-                _utils.vectorize(platform["build-for"]),
+                _utils.vectorize(platform.get("build-on", [platform_name])),
+                _utils.vectorize(platform.get("build-for", [platform_name])),
             ):
                 _, build_on_arch = _architectures.parse_base_and_architecture(
                     arch=build_on

--- a/craft_platforms/test/strategies.py
+++ b/craft_platforms/test/strategies.py
@@ -277,7 +277,7 @@ def platform(
     shorthand_keys: Optional[strategies.SearchStrategy[str]] = None,
     values: Union[strategies.SearchStrategy[craft_platforms.PlatformDict], None] = None,
 ) -> strategies.SearchStrategy[
-    Union[Dict[str, None], Dict[str, craft_platforms.PlatformDict]]
+    Union[Dict[str, Union[None, craft_platforms.PlatformDict]]]
 ]:
     """Generate a single platform in a dictionary.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -191,6 +191,7 @@ New Features
 For a complete list of commits, check out the `0.1.0`_ release on GitHub.
 
 
+.. _0.11.1: https://github.com/canonical/craft-platforms/releases/tag/0.11.1
 .. _0.11.0: https://github.com/canonical/craft-platforms/releases/tag/0.11.0
 .. _0.3.1: https://github.com/canonical/craft-platforms/releases/tag/0.3.1
 .. _0.3.0: https://github.com/canonical/craft-platforms/releases/tag/0.3.0

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -168,7 +168,7 @@ Features
 - Add support for Rockcraft build plans.
 
 For a complete list of commits, check out the `0.2.0`_ release on GitHub.
-
+g
 
 0.1.1 (2024-Jul-24)
 -------------------

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -13,6 +13,17 @@ Changelog
 
     For a complete list of commits, check out the `a.b.c`_ release on GitHub.
 
+0.11.1 (2026-04-03)
+-------------------
+
+Bug Fixes
+=========
+
+- Multi-base platforms for charms now accept expanded platforms passed by
+  Craft Application 6.
+
+For a complete list of commits, check out the `0.11.1`_ release on GitHub.
+
 0.11.0 (2026-02-11)
 -------------------
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -168,7 +168,6 @@ Features
 - Add support for Rockcraft build plans.
 
 For a complete list of commits, check out the `0.2.0`_ release on GitHub.
-g
 
 0.1.1 (2024-Jul-24)
 -------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,8 @@ def project_main_module() -> types.ModuleType:
 
         main_module = craft_platforms
     except ImportError:
-        pytest.fail(  # ty: ignore[invalid-argument-type] - this is fixed with pytest 9
-            reason="Failed to import the project's main module: check if it needs updating",  # ty: ignore[parameter-already-assigned] - this is fixed with pytest 9
+        pytest.fail(
+            reason="Failed to import the project's main module: check if it needs updating",  # ty: ignore[unknown-argument]
         )
     return main_module
 

--- a/tests/unit/charm/test_build.py
+++ b/tests/unit/charm/test_build.py
@@ -662,12 +662,11 @@ def test_build_plans_in_depth(base, build_base, platforms, expected):
             {
                 "ubuntu@24.04:amd64": {
                     "build-on": ["ubuntu@22.04:amd64"],
-                    "build-for": ["ubuntu@22.04:amd64"],
                 },
             },
-            r"Platform 'ubuntu@24.04:amd64' declares a base in the platform's name and declares an incompatible 'build-for' entry \(ubuntu@22.04\).",
-            "Either remove the base from the platform's name or remove the incompatible 'build-for' entry for the platform.",
-            id="platform-base-with-incompatible-entries",
+            r"Platform 'ubuntu@24.04:amd64' has mismatched bases in the 'build-on' and 'build-for' entries.",
+            "Use the same base for all 'build-on' and 'build-for' entries for the platform.",
+            id="platform-base-with-incompatible-build-on",
         ),
     ],
 )

--- a/tests/unit/charm/test_build.py
+++ b/tests/unit/charm/test_build.py
@@ -446,6 +446,69 @@ def test_build_plans_success(
             ],
             id="multi-base-complex",
         ),
+        pytest.param(
+            None,
+            None,
+            {
+                "ubuntu@24.04:amd64": {
+                    "build-on": ["s390x"],
+                    "build-for": ["amd64"],
+                },
+            },
+            [
+                craft_platforms.BuildInfo(
+                    "ubuntu@24.04:amd64",
+                    craft_platforms.DebianArchitecture("s390x"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                ),
+            ],
+            id="multi-base-set-arch",
+        ),
+        pytest.param(  # This is how craft-application expands the shorthand.
+            None,
+            None,
+            {
+                "ubuntu@24.04:amd64": {
+                    "build-on": ["ubuntu@24.04:amd64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            [
+                craft_platforms.BuildInfo(
+                    "ubuntu@24.04:amd64",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                ),
+            ],
+            id="multi-base-redundant",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "ubuntu@24.04:amd64": {
+                    "build-on": ["ubuntu@24.04:amd64", "ubuntu@24.04:riscv64"],
+                    "build-for": ["ubuntu@24.04:amd64"],
+                },
+            },
+            [
+                craft_platforms.BuildInfo(
+                    "ubuntu@24.04:amd64",
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                ),
+                craft_platforms.BuildInfo(
+                    "ubuntu@24.04:amd64",
+                    craft_platforms.DebianArchitecture("riscv64"),
+                    craft_platforms.DebianArchitecture("amd64"),
+                    craft_platforms.DistroBase("ubuntu", "24.04"),
+                ),
+            ],
+            id="multi-base-long-multi-build-on",
+        ),
     ],
 )
 def test_build_plans_in_depth(base, build_base, platforms, expected):
@@ -565,20 +628,46 @@ def test_build_plans_in_depth(base, build_base, platforms, expected):
             },
             "Platform 'my-platform' has mismatched bases in the 'build-on' and 'build-for' entries.",
             "Use the same base for all 'build-on' and 'build-for' entries for the platform.",
-            id="build-on-for-base-missing",
+            id="build-on-base-wrong",
         ),
         pytest.param(
             None,
             None,
             {
                 "ubuntu@24.04:amd64": {
-                    "build-on": ["amd64"],
+                    "build-on": ["ubuntu@22.04:amd64"],
                     "build-for": ["amd64"],
                 },
             },
-            "Platform 'ubuntu@24.04:amd64' declares a base in the platform's name and declares 'build-on' and 'build-for' entries.",
-            "Either remove the base from the platform's name or remove the 'build-on' and 'build-for' entries for the platform.",
+            "Platform 'ubuntu@24.04:amd64' has mismatched bases in the 'build-on' and 'build-for' entries.",
+            "Use the same base for all 'build-on' and 'build-for' entries for the platform.",
             id="platform-base-with-entries",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "ubuntu@24.04:amd64": {
+                    "build-on": ["ubuntu@22.04:amd64"],
+                    "build-for": ["ubuntu@22.04:amd64"],
+                },
+            },
+            r"Platform 'ubuntu@24.04:amd64' declares a base in the platform's name and declares an incompatible 'build-for' entry \(ubuntu@22.04\)",
+            "Either remove the base from the platform's name or remove the incompatible 'build-for' entry for the platform.",
+            id="build-on-base-wrong",
+        ),
+        pytest.param(
+            None,
+            None,
+            {
+                "ubuntu@24.04:amd64": {
+                    "build-on": ["ubuntu@22.04:amd64"],
+                    "build-for": ["ubuntu@22.04:amd64"],
+                },
+            },
+            r"Platform 'ubuntu@24.04:amd64' declares a base in the platform's name and declares an incompatible 'build-for' entry \(ubuntu@22.04\).",
+            "Either remove the base from the platform's name or remove the incompatible 'build-for' entry for the platform.",
+            id="platform-base-with-incompatible-entries",
         ),
     ],
 )


### PR DESCRIPTION
This accepts multi-base charms that have some redundancy as long as the build plans wouldn't differ from valid build plans still.

Once we pull this into Charmcraft it will fix https://github.com/canonical/charmcraft/issues/2620

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
