### PR TITLE
ci: test on Ubuntu 26.04 (Resolute)

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -20,6 +20,7 @@ jobs:
           "ubuntu-22.04",
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          "self-hosted-linux-amd64-resolute-large",
         ]
       fast-test-python-versions: '["3.10", "3.12", "3.14"]'
       slow-test-platforms: >
@@ -27,6 +28,7 @@ jobs:
           "ubuntu-22.04",
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          "self-hosted-linux-amd64-resolute-large",
         ]
       slow-test-python-versions: '["3.10", "3.12", "3.14"]'
       lowest-python-platform: ubuntu-22.04


### PR DESCRIPTION
This PR adds testing for Ubuntu 26.04 (Resolute) to the QA workflow. Resolute testing uses the 'self-hosted-linux-amd64-resolute-large' runner.

Fixes: #226