### PR TITLE
build(deps): update pytest to 8.4.2 for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dev = [
     "coverage[toml]~=7.4",
     "hypothesis>=6.108",
     "pytest~=9.0,>=9.0.3; python_version >= '3.10'",
-    "pytest~=8.0; python_version < '3.10'",
+    "pytest~=8.0,>=8.4.2; python_version < '3.10' and python_version >= '3.9'",
+    "pytest~=8.0; python_version < '3.9'",
     "pytest-check~=2.3",
     "pytest-cov~=5.0",
     "pytest-mock~=3.12",
@@ -59,7 +60,8 @@ test = [
     # Extra packages that are needed when using items from the craft-platforms.test
     # module.
     "pytest>=9.0.3; python_version >= '3.10'",
-    "pytest>=8.0; python_version < '3.10'",
+    "pytest>=8.4.2; python_version < '3.10' and python_version >= '3.9'",
+    "pytest>=8.0; python_version < '3.9'",
     "hypothesis~=6.108",
 ]
 lint = [

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 constraints = [
     { name = "build", specifier = ">=0.1.0" },
     { name = "iniconfig", specifier = ">=1.1.0" },
-    { name = "lxml", specifier = ">=6.1.0" },
+    { name = "lxml", specifier = ">=5.0" },
     { name = "markdown", specifier = ">=3.0" },
     { name = "markupsafe", specifier = ">=2.0" },
     { name = "pyparsing", specifier = ">=3.0.0" },
@@ -1037,7 +1037,8 @@ dev = [
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "mypy", extras = ["reports"], specifier = "~=1.11" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pytest", marker = "python_full_version < '3.10'", specifier = "~=8.0" },
+    { name = "pytest", marker = "python_full_version < '3.9'", specifier = "~=8.0" },
+    { name = "pytest", marker = "python_full_version == '3.9.*'", specifier = "~=8.0,>=8.4.2" },
     { name = "pytest", marker = "python_full_version >= '3.10'", specifier = "~=9.0,>=9.0.3" },
     { name = "pytest-check", specifier = "~=2.3" },
     { name = "pytest-cov", specifier = "~=5.0" },
@@ -1061,7 +1062,8 @@ docs = [
 lint = []
 test = [
     { name = "hypothesis", specifier = "~=6.108" },
-    { name = "pytest", marker = "python_full_version < '3.10'", specifier = ">=8.0" },
+    { name = "pytest", marker = "python_full_version < '3.9'", specifier = ">=8.0" },
+    { name = "pytest", marker = "python_full_version == '3.9.*'", specifier = ">=8.4.2" },
     { name = "pytest", marker = "python_full_version >= '3.10'", specifier = ">=9.0.3" },
 ]
 types = [{ name = "mypy", extras = ["reports"], specifier = "~=1.11" }]


### PR DESCRIPTION
Update pytest constraints to require at least 8.4.2 for Python 3.9. This avoids the CVE-related failure.