### PR TITLE
ci: test on Ubuntu 26.04 (Resolute)

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -20,6 +20,8 @@ jobs:
           "ubuntu-22.04",
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          "ubuntu-26.04",
+          "ubuntu-26.04-arm",
         ]
       fast-test-python-versions: '["3.10", "3.12", "3.14"]'
       slow-test-platforms: >
@@ -27,6 +29,8 @@ jobs:
           "ubuntu-22.04",
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          "ubuntu-26.04",
+          "ubuntu-26.04-arm",
         ]
       slow-test-python-versions: '["3.10", "3.12", "3.14"]'
       lowest-python-platform: ubuntu-22.04


### PR DESCRIPTION
Add ubuntu-26.04 and ubuntu-26.04-arm to fast and slow test platforms in qa.yaml.

Fixes #226