### PR TITLE
fix: add support for armv8l

### DIFF
--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -115,8 +115,9 @@ _ARCH_TRANSLATIONS_DEB_TO_GRUB = {
 
 # architecture translations from the other syntaxes to deb/snap syntax
 _ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
-    platform: deb for (deb, platform) in _ARCH_TRANSLATIONS_DEB_TO_PLATFORM.items()
-} | {"armv8l": "armhf"}
+    **{platform: deb for (deb, platform) in _ARCH_TRANSLATIONS_DEB_TO_PLATFORM.items()},
+    "armv8l": "armhf",
+}
 
 
 def parse_base_and_architecture(

--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -116,7 +116,7 @@ _ARCH_TRANSLATIONS_DEB_TO_GRUB = {
 # architecture translations from the other syntaxes to deb/snap syntax
 _ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
     **{platform: deb for (deb, platform) in _ARCH_TRANSLATIONS_DEB_TO_PLATFORM.items()},
-    "armv8l": "armhf",
+    "armv8l": "armhf",  # ARMv8 processor running in 32-bit LE mode
 }
 
 

--- a/craft_platforms/_architectures.py
+++ b/craft_platforms/_architectures.py
@@ -116,7 +116,7 @@ _ARCH_TRANSLATIONS_DEB_TO_GRUB = {
 # architecture translations from the other syntaxes to deb/snap syntax
 _ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
     platform: deb for (deb, platform) in _ARCH_TRANSLATIONS_DEB_TO_PLATFORM.items()
-}
+} | {"armv8l": "armhf"}
 
 
 def parse_base_and_architecture(

--- a/tests/unit/test_architectures.py
+++ b/tests/unit/test_architectures.py
@@ -68,10 +68,18 @@ def test_debian_architecture_to_platform_arch(given, expected):
     assert given.to_platform_arch() == expected
 
 
-@pytest.mark.parametrize("machine", ["aarch64", "x86_64", "riscv64"])
-def test_debian_architecture_from_host(monkeypatch, machine):
+@pytest.mark.parametrize(
+    ("machine", "expected"),
+    [
+        ("aarch64", "aarch64"),
+        ("x86_64", "x86_64"),
+        ("riscv64", "riscv64"),
+        ("armv8l", "armv7l"),
+    ],
+)
+def test_debian_architecture_from_host(monkeypatch, machine, expected):
     monkeypatch.setattr(platform, "machine", lambda: machine)
-    assert DebianArchitecture.from_host().to_platform_arch() == machine
+    assert DebianArchitecture.from_host().to_platform_arch() == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`armv8l` should be mapped to `armhf` and `armv7l` according to the implementation in canonical/craft-parts#696.

This fixes #243.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
