### PR TITLE
ci: align policy OSV scanner inputs with starbase

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -5,3 +5,10 @@ on:
 jobs:
   policy:
     uses: canonical/starflow/.github/workflows/policy.yaml@main
+    with:
+      osv-extra-args: "--config=osv-scanner.toml"
+      osv-exclude-paths: |
+        docs
+      uv-export-no-groups: |
+        docs
+        docs-sphinx-stack

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,16 +1,1 @@
-# Ignore pytest tmpdir vulnerability (CVE-2025-71176) for versions older than
-# 9.0.3. These versions are only resolved for Python <3.10 where pytest 9.0.3
-# (the fix) is not available. Python >=3.10 uses the fixed pytest 9.0.3.
-[[PackageOverrides]]
-name = "pytest"
-version = "8.3.5"
-ecosystem = "PyPI"
-vulnerability.ignore = true
-reason = "Only resolved for Python <3.9 where no fix is available (pytest 9.0.3 requires Python >=3.10)"
-
-[[PackageOverrides]]
-name = "pytest"
-version = "8.4.2"
-ecosystem = "PyPI"
-vulnerability.ignore = true
-reason = "Only resolved for Python 3.9 where no fix is available (pytest 9.0.3 requires Python >=3.10)"
+# OSV Scanner configuration


### PR DESCRIPTION
## Summary
- update .github/workflows/policy.yaml to pass OSV scanner inputs:
  - osv-extra-args: "--config=osv-scanner.toml"
  - osv-exclude-paths with docs
  - uv-export-no-groups with docs and docs-sphinx-stack
- ensure requirements-find-args is not present in that with block
- set root osv-scanner.toml to:
  - # OSV Scanner configuration

## Dependency/lockfile impact
No dependency or lockfile changes were required for this fix because it only adjusts reusable policy workflow inputs and scanner config file content.

## Validation
- verified workflow contains required keys and omits requirements-find-args
- verified osv-scanner.toml content matches expected single-line config comment
